### PR TITLE
Changing block view configuration to use default

### DIFF
--- a/Resources/config/default_layouts.yml
+++ b/Resources/config/default_layouts.yml
@@ -1,6 +1,6 @@
 blocks:
     userprofiling:
         views:
-            userprofiling:
+            default:
                 template: EzUserProfilingBlockBundle:blocks:userprofiling.html.twig
                 name: User Profiling Block view


### PR DESCRIPTION
At least with eZ Platform EE 1.11.1 you get an error with the previous configuration:

  [Symfony\Component\Config\Definition\Exception\InvalidTypeException]
  Invalid type for path "ez_systems_landing_page_field_type.blocks.userprofil
  ing.views.userprofiling.template". Expected scalar, but got array.